### PR TITLE
fix rightPad check

### DIFF
--- a/lib/Protocol/Protobuf/Adapters/Resultset.js
+++ b/lib/Protocol/Protobuf/Adapters/Resultset.js
@@ -210,7 +210,7 @@ function decodeOpaqueByteString (reader, options) {
         const data = new Buffer(reader.getFieldDecoder().readBytes(options.length - 1));
         /* eslint-enable node/no-deprecated-api */
 
-        if (options.metadata.flags) {
+        if (options.metadata.flags & 1) {
             return rightPad(data, options.metadata.length);
         }
 
@@ -220,7 +220,7 @@ function decodeOpaqueByteString (reader, options) {
     // remove the extra '\0' defined by the protocol
     let data = reader.getFieldDecoder().readString(options.length - 1);
 
-    if (options.metadata.flags) {
+    if (options.metadata.flags & 1) {
         data = rightPad(data, options.metadata.length);
     }
 


### PR DESCRIPTION
As per https://dev.mysql.com/doc/internals/en/x-protocol-messages-messages.html#x-protocol-messages-resultsets the correct check for the rightPad flag is `.flags & 1`.
ping @ruiquelhas